### PR TITLE
Fix setTokenOpacity to update token for players.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
-3. Scroll down to '....'
+3. If macro related, sample macro code '....'
 4. See error
 
 **Expected behavior**
@@ -20,16 +20,15 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**MapTool Info**
+- Version: 1.5.4.3
+- Install: New, Upgrade [previous version], or JAR [Java Version]
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows, Linux [Ubuntu, Debian, CentOS, etc], MacOS]
+ - Version [10, 18.04]
 
 **Additional context**
 Add any other context about the problem here.
+From MapTool, paste info from menu Help -> Gather Debug Information...
+You can also attach files (drag and drop here) such as log files or paste a file sharing link.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/submit-a-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-a-question.md
@@ -1,0 +1,13 @@
+---
+name: Submit a Question
+about: Technical Questions
+
+---
+
+**Describe your question**
+A clear and concise question regarding this Fork, how to contribute, or similar topics.
+
+*This should NOT be used for general questions on use of MapTool*
+For user support, please post your question on the Forums: http://forums.rptools.net
+Or on our Discord channel: [Invite Link](https://discord.gg/2FCwhZ9)
+Or on Reddit: [r/MapTool](https://www.reddit.com/r/MapTool/)

--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,12 @@ Thumbs.db
 target/
 build/
 out/
+\${sys:appHome}/
 
 # Automatically Generated
 ################################################################################
 package/windows/MapTool.iss
+src/main/resources/sentry.properties
 
 
 # IDEs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at Jamz@Nerps.net. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'application'
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'com.diffplug.gradle.spotless'
+apply plugin: 'jacoco'
 
 // Definitions
 defaultTasks 'clean', 'build'
@@ -92,6 +93,11 @@ spotless {
 		// or spaces. Takes an integer argument if you don't like 4
 		indentWithTabs()
 	}
+}
+
+jacoco {
+toolVersion = "0.8.1"
+reportsDir = file("$buildDir/reports/jacoco")
 }
 
 // Set eclipse natures, access rules, and other settings
@@ -245,6 +251,9 @@ dependencies {
 	// testCompile dependency to testCompile 'org.testng:testng:6.8.1' and add
 	// 'test.useTestNG()' to your build script.
 	testCompile 'junit:junit:4.12'
+
+	// For mocking features during unit tests
+	testCompile group: 'org.mockito', name: 'mockito-core', version: '2.1.0'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ spotless {
 	}
 
 	format 'misc', {
-		target '**/*.gradle', '**/*.md', '**/.gitignore'
+		target '**/*.gradle', '**/.gitignore'
 
 		// spotless has built-in rules for most basic formatting tasks
 		trimTrailingWhitespace()

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -100,7 +100,7 @@ public class TokenImage extends AbstractFunction {
 			float newOpacity = token.setTokenOpacity(Float.parseFloat(args.get(0).toString()));
 			zone.putToken(token);
 			MapTool.serverCommand().putToken(zone.getId(), token);
-			return newOpacity; 
+			return newOpacity;
 		}
 
 		if (functionName.equals("getTokenOpacity")) {

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -97,8 +97,10 @@ public class TokenImage extends AbstractFunction {
 					throw new ParserException(I18N.getText("macro.function.general.noImpersonated", functionName));
 				}
 			}
-
-			return token.setTokenOpacity(Float.parseFloat(args.get(0).toString()));
+			float newOpacity = token.setTokenOpacity(Float.parseFloat(args.get(0).toString()));
+			zone.putToken(token);
+			MapTool.serverCommand().putToken(zone.getId(), token);
+			return newOpacity; 
 		}
 
 		if (functionName.equals("getTokenOpacity")) {

--- a/src/main/resources/sentry.properties
+++ b/src/main/resources/sentry.properties
@@ -1,4 +1,0 @@
-dsn=http://dontlogme:indevelopment@localhost/1234
-environment=Development
-stacktrace.app.packages=net.rptools.lib,net.rptools.maptool
-release=SNAPSHOT-599398f


### PR DESCRIPTION
Fix for issue #107. Instead of directly returning of `setTokenOpacity`, the result is captured and `putToken` functions are run before returning, similar to other functions which alter how a token is displayed. 