### PR TITLE
Return and catch abort func

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -54,7 +54,8 @@ public class MapToolLineParser {
 			CurrentInitiativeFunction.getInstance(), DefineMacroFunction.getInstance(), EvalMacroFunctions.getInstance(), FindTokenFunctions.getInstance(), HasImpersonated.getInstance(),
 			InitiativeRoundFunction.getInstance(), InputFunction.getInstance(), IsTrustedFunction.getInstance(), JSONMacroFunctions.getInstance(), LookupTableFunction.getInstance(),
 			MacroArgsFunctions.getInstance(), MacroDialogFunctions.getInstance(), MacroFunctions.getInstance(), MacroLinkFunction.getInstance(), MapFunctions.getInstance(),
-			MiscInitiativeFunction.getInstance(), PlayerFunctions.getInstance(), RemoveAllFromInitiativeFunction.getInstance(), ReturnFunction.getInstance(), StateImageFunction.getInstance(), StringFunctions.getInstance(),
+			MiscInitiativeFunction.getInstance(), PlayerFunctions.getInstance(), RemoveAllFromInitiativeFunction.getInstance(), ReturnFunction.getInstance(), StateImageFunction.getInstance(),
+			StringFunctions.getInstance(),
 			StrListFunctions.getInstance(), StrPropFunctions.getInstance(), SwitchTokenFunction.getInstance(), TokenAddToInitiativeFunction.getInstance(), TokenBarFunction.getInstance(),
 			TokenCopyDeleteFunctions.getInstance(), TokenGMNameFunction.getInstance(), TokenHaloFunction.getInstance(), TokenImage.getInstance(), TokenInitFunction.getInstance(),
 			TokenInitHoldFunction.getInstance(), TokenLabelFunction.getInstance(), TokenLightFunctions.getInstance(), TokenLocationFunctions.getInstance(), TokenNameFunction.getInstance(),
@@ -1431,7 +1432,7 @@ public class MapToolLineParser {
 			try {
 				macroOutput = runMacroBlock(macroResolver, tokenInContext, macroBody, macroContext);
 				// Copy the return value of the macro into our current variable scope.
-			  resolver.setVariable("macro.return", macroResolver.getVariable("macro.return"));
+				resolver.setVariable("macro.return", macroResolver.getVariable("macro.return"));
 			} catch (ReturnFunctionException returnEx) {
 				Object result = returnEx.getResult();
 				if (result != null) {

--- a/src/main/java/net/rptools/maptool/client/functions/ReturnFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ReturnFunction.java
@@ -1,0 +1,85 @@
+/*
+ * This software Copyright by the RPTools.net development team, and licensed under the Affero GPL Version 3 or, at your option, any later version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License * along with this source Code. If not, please visit <http://www.gnu.org/licenses/> and specifically the Affero license text
+ * at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import net.rptools.parser.Parser;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.function.AbstractFunction;
+import net.rptools.parser.function.ParameterException;
+
+/**
+ * Aborts the current parser evaluation.
+ * 
+ * @author oliver.szymanski
+ */
+public class ReturnFunction extends AbstractFunction {
+	public ReturnFunction() {
+		super(1, 2, "return");
+	}
+
+	/** The singleton instance. */
+	private final static ReturnFunction instance = new ReturnFunction();
+
+	/**
+	 * Gets the Input instance.
+	 * 
+	 * @return the instance.
+	 */
+	public static ReturnFunction getInstance() {
+		return instance;
+	}
+
+	@Override
+	public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) throws ParserException {
+
+		BigDecimal value = (BigDecimal) parameters.get(0);
+		if (value.intValue() == 0) {
+			ReturnFunctionException returnException = new ReturnFunctionException(null);
+			if (parameters.size() > 1) {
+				returnException.setResult(parameters.get(1));
+			}
+			throw returnException;
+		} else
+			return new BigDecimal(value.intValue());
+	}
+
+	public void checkParameters(List<Object> parameters) throws ParameterException {
+		super.checkParameters(parameters);
+
+		Object param = parameters.get(0);
+		if (!(param instanceof BigDecimal)) {
+			Object[] arrobject = new Object[2];
+			arrobject[0] = param == null ? "null" : param.getClass().getName();
+			arrobject[1] = BigDecimal.class.getName();
+			throw new ParameterException(String.format("Illegal argument type %s, expecting %s", arrobject));
+		}
+	}
+
+	/** Exception type thrown by return() function. Semantics are to silently halt the current execution. */
+	public static class ReturnFunctionException extends ParserException {
+
+		private Object result;
+
+		public Object getResult() {
+			return result;
+		}
+
+		public void setResult(Object result) {
+			this.result = result;
+		}
+
+		public ReturnFunctionException(Object result) {
+			super("");
+			this.result = result;
+		}
+	}
+}


### PR DESCRIPTION
To exit a function/macro use the new "return" function.
First parameter is same as in "abort" function, so the return will only
do anything if first parameter is 0. Second parameter is an optional
return value, which will be put in macro.return and in output text of
the macro using the "return" function.

E.g.:
[return(0, "returned hello world")]
Flow will end and leave the macro continuing in the calling macro once the return function is evaluated.
To not stop all macro execution when some macro in the callstack is
calling "abort(0)" you can set a variable named "macro.catchAbort=1".
All macros in the callstack will still be aborted, except the one with
"macro.catchAbort=1" in scope.

E.g.:
[h: resultText = "defaultValue"]
[h: resultText = abort(0)]
[r: resultText]
Will not abort but instead have "defaultValue" in resultText. The abort can happen anywhere above in the callstack, so could also happen in another macro that we call.